### PR TITLE
Handle missing FAL_KEY gracefully

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -13,7 +13,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /* ---------- ENV & FAL ---------- */
 dotenv.config({ path: path.join(__dirname, '.env') });
-fal.config({ credentials: process.env.FAL_KEY.trim() });
+const falKey = process.env.FAL_KEY?.trim();
+if (falKey) {
+  fal.config({ credentials: falKey });
+} else {
+  console.warn('⚠️  FAL_KEY environment variable is missing');
+}
 
 /* ---------- tiny JSON “DB” helpers ---------- */
 const read = async (f, d = []) =>


### PR DESCRIPTION
## Summary
- avoid server crash when FAL_KEY env var is unset by checking before using

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm --prefix server test` *(fails: Missing script: "test")*
- `npm --prefix client test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68945a50fcd8832cac405d563f3be5c9