### PR TITLE
Validate FAL_KEY before configuring fal client

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -13,7 +13,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /* ---------- ENV & FAL ---------- */
 dotenv.config({ path: path.join(__dirname, '.env') });
-fal.config({ credentials: process.env.FAL_KEY.trim() });
+const falKey = process.env.FAL_KEY;
+if (!falKey) {
+  const msg = 'Missing FAL_KEY environment variable';
+  console.error(msg);
+  throw new Error(msg);
+}
+fal.config({ credentials: falKey.trim() });
 
 /* ---------- tiny JSON “DB” helpers ---------- */
 const read = async (f, d = []) =>


### PR DESCRIPTION
## Summary
- validate `FAL_KEY` env var before trimming and configuring the fal client
- emit a clear error when `FAL_KEY` is missing

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68945cc4b818832c9fb166eac0b5cfbb