### PR TITLE
Preload sidebar thumbnails

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -31,10 +31,23 @@ export default function App() {
 
   useEffect(() => {
     axios.get(`${API}/api/loras`).then((r) => setLoraList(r.data));
-    axios.get(`${API}/api/boards`).then((r) => {
-      setBoards(r.data);
-      if (r.data.length) setBid(r.data[r.data.length - 1].id);
-    });
+    (async () => {
+      const { data: boards } = await axios.get(`${API}/api/boards`);
+      setBoards(boards);
+      if (boards.length) setBid(boards[boards.length - 1].id);
+
+      const thumbsEntries = await Promise.all(
+        boards.map(async (b) => {
+          const { data: imgs } = await axios.get(`${API}/api/boards/${b.id}`);
+          const last = imgs.at(-1)?.url;
+          return last ? [b.id, last] : null;
+        })
+      );
+      setThumbs((t) => ({
+        ...t,
+        ...Object.fromEntries(thumbsEntries.filter(Boolean)),
+      }));
+    })();
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Preload board thumbnails after fetching boards so sidebar previews render immediately

## Testing
- `npm --prefix client ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689470e454d4832ca6891aa6459f310d