### PR TITLE
Fix dark theme card and control bar styling

### DIFF
--- a/client/src/components/ControlBar.jsx
+++ b/client/src/components/ControlBar.jsx
@@ -14,7 +14,7 @@ export default function ControlBar({
   err
 }) {
   return (
-    <div className="fixed inset-x-0 bottom-0 z-40 border-t border-muted bg-background/95 px-4 py-3 backdrop-blur">
+    <div className="fixed inset-x-0 bottom-0 z-40 border-t border-muted bg-background px-4 py-3">
       <div className="mx-auto flex max-w-3xl flex-wrap items-center gap-3">
         <Btn onClick={() => setOpenLora(true)} className="h-10 px-3">
           {pick ? pick.name : 'Add lora'}

--- a/client/src/components/ImageCard.jsx
+++ b/client/src/components/ImageCard.jsx
@@ -22,7 +22,7 @@ export default function ImageCard({ img, boardId, onRemove, onShow }) {
   };
 
   return (
-    <div className="relative space-y-2 rounded-lg bg-muted/40 p-3 shadow group">
+    <div className="relative space-y-2 rounded-lg bg-muted p-3 shadow group">
       <p className="text-xs">{img.prompt || '(no prompt)'}</p>
       {img.lora && (
         <span className="rounded bg-primary/20 px-2 py-0.5 text-[10px] text-primary">

--- a/client/src/components/LoaderCard.jsx
+++ b/client/src/components/LoaderCard.jsx
@@ -1,7 +1,7 @@
 /* client/src/components/LoaderCard.jsx */
 export default function LoaderCard() {
   return (
-    <div className="flex h-[310px] flex-col rounded-lg bg-muted/40 p-3 shadow">
+    <div className="flex h-[310px] flex-col rounded-lg bg-muted p-3 shadow">
       <div className="flex flex-1 items-center justify-center">
         <svg
           className="h-10 w-10 animate-spin text-primary"

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -3,11 +3,26 @@
 @tailwind components;
 @tailwind utilities;
 
-/* --- наш фон + текст по умолчанию --- */
-html, body, #root {
+@layer base {
+  :root {
+    --background: 222.2 47.4% 11.2%;
+    --foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --border: 217.2 32.6% 17.5%;
+    --primary: 263.4 70% 50.5%;
+    --primary-foreground: 210 40% 98%;
+  }
+
+  body {
+    @apply bg-background text-foreground;
+  }
+}
+
+html,
+body,
+#root {
   height: 100%;
-  background: #121212;   /* глубокий тёмный */
-  color: #e5e5e5;        /* светлый текст, чтобы не пропал */
 }
 
 /* скроллбар (необязательно) */

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,6 +1,27 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{js,jsx}'],
-  theme: { extend: {} },
-  plugins: []
+  theme: {
+    extend: {
+      colors: {
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        border: 'hsl(var(--border))',
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+    },
+  },
+  plugins: [],
 };


### PR DESCRIPTION
## Summary
- restore global dark theme tokens and apply them to the page
- map tailwind utilities to the new theme variables
- give gallery cards and loader cards solid muted backgrounds
- make the bottom control bar opaque

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68948ee8ab0c832c87149dffc81d4d3e