### PR TITLE
Allow configurable API base URL in frontend

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,2 @@
+VITE_API_URL=http://localhost:4000
+

--- a/client/README.md
+++ b/client/README.md
@@ -10,3 +10,13 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## API configuration
+
+The frontend uses an environment variable to determine the backend API URL. Copy `.env.example` to `.env` and set `VITE_API_URL` to the address of your backend, e.g.
+
+```bash
+VITE_API_URL=http://192.168.200.251:4000
+```
+
+During development the app falls back to `http://localhost:4000` if the variable is not set.

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,5 @@
 /* client/src/App.jsx */
-import axios from 'axios';
+import api from './api';
 import React, { useState, useEffect, useRef } from 'react';
 
 import Sidebar from './components/Sidebar';
@@ -8,8 +8,6 @@ import ImageCard from './components/ImageCard';
 import LoraModal from './components/LoraModal';
 import ImageModal from './components/ImageModal';
 import ControlBar from './components/ControlBar';
-
-const API = import.meta.env.VITE_API_URL || '';
 
 export default function App() {
   const [boards, setBoards] = useState([]);
@@ -42,16 +40,16 @@ export default function App() {
   };
 
   useEffect(() => {
-    axios.get(`${API}/api/loras`).then((r) => setLoraList(r.data));
+    api.get('/api/loras').then((r) => setLoraList(r.data));
     (async () => {
-      const { data: boards } = await axios.get(`${API}/api/boards`);
+      const { data: boards } = await api.get('/api/boards');
       setBoards(boards);
       if (boards.length) setBid(boards[boards.length - 1].id);
       const cacheObj = {};
       const thumbsObj = {};
       await Promise.all(
         boards.map(async (b) => {
-          const { data: imgs } = await axios.get(`${API}/api/boards/${b.id}`);
+          const { data: imgs } = await api.get(`/api/boards/${b.id}`);
           cacheObj[b.id] = imgs;
           cacheImages(imgs);
           const last = imgs.at(-1)?.url;
@@ -72,7 +70,7 @@ export default function App() {
         setThumbs((t) => ({ ...t, [bid]: cached[cached.length - 1].url }));
       return;
     }
-    axios.get(`${API}/api/boards/${bid}`).then((r) => {
+    api.get(`/api/boards/${bid}`).then((r) => {
       setGal(r.data);
       setCache((c) => ({ ...c, [bid]: r.data }));
       if (r.data.length)
@@ -123,8 +121,8 @@ export default function App() {
       if (pick?.url) fd.append('lora_path', pick.url);
       if (pick?.name) fd.append('lora_name', pick.name);
 
-      const { data } = await axios.post(
-        `${API}/api/boards/${bid}/generate`,
+      const { data } = await api.post(
+        `/api/boards/${bid}/generate`,
         fd
       );
 
@@ -149,7 +147,7 @@ export default function App() {
   };
 
   const newBoard = async () => {
-    const { data } = await axios.post(`${API}/api/boards`);
+    const { data } = await api.post('/api/boards');
     setBoards([...boards, data]);
     setBid(data.id);
     setGal([]);
@@ -165,7 +163,7 @@ export default function App() {
         onNew={newBoard}
         onPick={setBid}
         onDelete={async (id) => {
-          await axios.delete(`${API}/api/boards/${id}`);
+          await api.delete(`/api/boards/${id}`);
           setBoards(boards.filter((b) => b.id !== id));
           setCache((c) => {
             const { [id]: _, ...rest } = c;

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+// Determine the API base URL.
+// Priority:
+// 1. VITE_API_URL environment variable
+// 2. During local development, fall back to the backend running on localhost:4000
+// 3. In production, default to the current origin
+const baseURL =
+  import.meta.env.VITE_API_URL ||
+  (import.meta.env.DEV ? 'http://localhost:4000' : window.location.origin);
+
+export default axios.create({ baseURL });
+

--- a/client/src/components/ImageCard.jsx
+++ b/client/src/components/ImageCard.jsx
@@ -1,8 +1,6 @@
 /* client/src/components/ImageCard.jsx */
-import axios from 'axios';
+import api from '../api';
 import { Download, Trash2 } from 'lucide-react';
-
-const API = import.meta.env.VITE_API_URL || '';
 
 export default function ImageCard({ img, boardId, onRemove, onShow }) {
   const save = async () => {
@@ -17,7 +15,7 @@ export default function ImageCard({ img, boardId, onRemove, onShow }) {
   };
 
   const del = async () => {
-    await axios.delete(`${API}/api/boards/${boardId}/images/${img.id}`);
+    await api.delete(`/api/boards/${boardId}/images/${img.id}`);
     onRemove(img.id);
   };
 

--- a/client/src/components/LoraModal.jsx
+++ b/client/src/components/LoraModal.jsx
@@ -1,10 +1,8 @@
 /* client/src/components/LoraModal.jsx */
 import { useState, useEffect } from 'react';
-import axios from 'axios';
+import api from '../api';
 import { Plus, X, Pencil, Trash2 } from 'lucide-react';
 import Compare from './Compare';
-
-const API = import.meta.env.VITE_API_URL || '';
 
 export default function LoraModal({
   open,
@@ -37,7 +35,7 @@ export default function LoraModal({
 
   const handleDelete = async (id) => {
     if (!window.confirm('Удалить эту LoRA?')) return;
-    await axios.delete(`${API}/api/loras/${id}`);
+    await api.delete(`/api/loras/${id}`);
     onDelete(id);
     if (editId === id) reset();
   };
@@ -52,10 +50,10 @@ export default function LoraModal({
     Object.entries(files).forEach(([k, v]) => v && fd.append(k, v));
 
     if (editId > 0) {
-      await axios.put(`${API}/api/loras/${editId}`, fd);
+      await api.put(`/api/loras/${editId}`, fd);
       onUpdate(editId, f);
     } else {
-      const { data } = await axios.post(`${API}/api/loras`, fd);
+      const { data } = await api.post('/api/loras', fd);
       onAdd(data);
     }
     reset();


### PR DESCRIPTION
## Summary
- centralize axios configuration with environment-based base URL
- route all frontend API calls through this instance
- document and provide `.env.example` for backend URL setup

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689495c2c550832ca1c84933a3f54175