### PR TITLE
Use shared axios API helper with configurable base URL

### DIFF
--- a/client/.env.development
+++ b/client/.env.development
@@ -1,1 +1,1 @@
-VITE_API_URL=http://localhost:4000
+VITE_API_URL=http://localhost:4000/api

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,2 +1,2 @@
-VITE_API_URL=http://localhost:4000
+VITE_API_URL=http://localhost:4000/api
 

--- a/client/README.md
+++ b/client/README.md
@@ -13,10 +13,17 @@ If you are developing a production application, we recommend using TypeScript wi
 
 ## API configuration
 
-The frontend uses an environment variable to determine the backend API URL. Copy `.env.example` to `.env` and set `VITE_API_URL` to the address of your backend, e.g.
+The frontend uses an environment variable to determine the backend API URL. Copy `.env.example` to `.env.development` and set `VITE_API_URL` to the address of your backend API, e.g.
 
 ```bash
-VITE_API_URL=http://192.168.200.251:4000
+VITE_API_URL=http://192.168.200.251:4000/api
 ```
 
-During development the app falls back to `http://localhost:4000` if the variable is not set.
+For production deployments, create `.env.production`:
+
+```bash
+# .env.production
+VITE_API_URL=https://kontext.gosystem.io/api
+```
+
+If `VITE_API_URL` is not set, requests default to `${window.location.origin}/api`.

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -40,16 +40,16 @@ export default function App() {
   };
 
   useEffect(() => {
-    api.get('/api/loras').then((r) => setLoraList(r.data));
+    api.get('/loras').then((r) => setLoraList(r.data));
     (async () => {
-      const { data: boards } = await api.get('/api/boards');
+      const { data: boards } = await api.get('/boards');
       setBoards(boards);
       if (boards.length) setBid(boards[boards.length - 1].id);
       const cacheObj = {};
       const thumbsObj = {};
       await Promise.all(
         boards.map(async (b) => {
-          const { data: imgs } = await api.get(`/api/boards/${b.id}`);
+          const { data: imgs } = await api.get(`/boards/${b.id}`);
           cacheObj[b.id] = imgs;
           cacheImages(imgs);
           const last = imgs.at(-1)?.url;
@@ -70,7 +70,7 @@ export default function App() {
         setThumbs((t) => ({ ...t, [bid]: cached[cached.length - 1].url }));
       return;
     }
-    api.get(`/api/boards/${bid}`).then((r) => {
+    api.get(`/boards/${bid}`).then((r) => {
       setGal(r.data);
       setCache((c) => ({ ...c, [bid]: r.data }));
       if (r.data.length)
@@ -122,7 +122,7 @@ export default function App() {
       if (pick?.name) fd.append('lora_name', pick.name);
 
       const { data } = await api.post(
-        `/api/boards/${bid}/generate`,
+        `/boards/${bid}/generate`,
         fd
       );
 
@@ -147,7 +147,7 @@ export default function App() {
   };
 
   const newBoard = async () => {
-    const { data } = await api.post('/api/boards');
+    const { data } = await api.post('/boards');
     setBoards([...boards, data]);
     setBid(data.id);
     setGal([]);
@@ -163,7 +163,7 @@ export default function App() {
         onNew={newBoard}
         onPick={setBid}
         onDelete={async (id) => {
-          await api.delete(`/api/boards/${id}`);
+          await api.delete(`/boards/${id}`);
           setBoards(boards.filter((b) => b.id !== id));
           setCache((c) => {
             const { [id]: _, ...rest } = c;

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -2,12 +2,10 @@ import axios from 'axios';
 
 // Determine the API base URL.
 // Priority:
-// 1. VITE_API_URL environment variable
-// 2. During local development, fall back to the backend running on localhost:4000
-// 3. In production, default to the current origin
+// 1. `VITE_API_URL` environment variable
+// 2. Current origin with `/api` path
 const baseURL =
-  import.meta.env.VITE_API_URL ||
-  (import.meta.env.DEV ? 'http://localhost:4000' : window.location.origin);
+  import.meta.env.VITE_API_URL || `${window.location.origin}/api`;
 
 export default axios.create({ baseURL });
 

--- a/client/src/components/ImageCard.jsx
+++ b/client/src/components/ImageCard.jsx
@@ -15,7 +15,7 @@ export default function ImageCard({ img, boardId, onRemove, onShow }) {
   };
 
   const del = async () => {
-    await api.delete(`/api/boards/${boardId}/images/${img.id}`);
+    await api.delete(`/boards/${boardId}/images/${img.id}`);
     onRemove(img.id);
   };
 

--- a/client/src/components/LoraModal.jsx
+++ b/client/src/components/LoraModal.jsx
@@ -35,7 +35,7 @@ export default function LoraModal({
 
   const handleDelete = async (id) => {
     if (!window.confirm('Удалить эту LoRA?')) return;
-    await api.delete(`/api/loras/${id}`);
+    await api.delete(`/loras/${id}`);
     onDelete(id);
     if (editId === id) reset();
   };
@@ -50,10 +50,10 @@ export default function LoraModal({
     Object.entries(files).forEach(([k, v]) => v && fd.append(k, v));
 
     if (editId > 0) {
-      await api.put(`/api/loras/${editId}`, fd);
+      await api.put(`/loras/${editId}`, fd);
       onUpdate(editId, f);
     } else {
-      const { data } = await api.post('/api/loras', fd);
+      const { data } = await api.post('/loras', fd);
       onAdd(data);
     }
     reset();


### PR DESCRIPTION
## Summary
- centralize API requests through a new axios instance with `VITE_API_URL` or `window.location.origin + /api`
- remove hardcoded localhost URLs in React components
- document production API URL and sample environment files

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68949bdd803c832caf4026a55f830fb5