### PR TITLE
Use shared api helper and env URL

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,5 @@
 /* client/src/App.jsx */
-import api from './api';
+import { api } from './api';
 import React, { useState, useEffect, useRef } from 'react';
 
 import Sidebar from './components/Sidebar';

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,11 +1,14 @@
-import axios from 'axios';
+import axios from "axios";
 
-// Determine the API base URL.
-// Priority:
-// 1. `VITE_API_URL` environment variable
-// 2. Current origin with `/api` path
-const baseURL =
-  import.meta.env.VITE_API_URL || `${window.location.origin}/api`;
+// 1️⃣ first priority - env variable injected at build
+const envUrl = import.meta.env.VITE_API_URL?.trim();
 
-export default axios.create({ baseURL });
+// 2️⃣ second - same-origin backend on :4000 (for dev preview)
+const sameOriginUrl = `${window.location.protocol}//${window.location.hostname}:4000/api`;
+
+// final baseURL
+const baseURL = envUrl || sameOriginUrl;
+
+console.log("[API] baseURL =", baseURL); // remove later
+export const api = axios.create({ baseURL, withCredentials: true });
 

--- a/client/src/components/ImageCard.jsx
+++ b/client/src/components/ImageCard.jsx
@@ -1,11 +1,10 @@
 /* client/src/components/ImageCard.jsx */
-import api from '../api';
+import { api } from '../api';
 import { Download, Trash2 } from 'lucide-react';
 
 export default function ImageCard({ img, boardId, onRemove, onShow }) {
   const save = async () => {
-    const res = await fetch(img.url, { mode: 'cors' });
-    const blob = await res.blob();
+    const { data: blob } = await api.get(img.url, { responseType: 'blob', withCredentials: false });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;

--- a/client/src/components/LoraModal.jsx
+++ b/client/src/components/LoraModal.jsx
@@ -1,6 +1,6 @@
 /* client/src/components/LoraModal.jsx */
 import { useState, useEffect } from 'react';
-import api from '../api';
+import { api } from '../api';
 import { Plus, X, Pencil, Trash2 } from 'lucide-react';
 import Compare from './Compare';
 


### PR DESCRIPTION
## Summary
- Strengthen client API helper to prioritize `VITE_API_URL` and fall back to same-origin `:4000` endpoint
- Replace direct fetch usage and ensure components import the shared `api`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6894a26877c0832ca9578567e9c4b96c