### PR TITLE
Enable public domain access

### DIFF
--- a/client/.env.development
+++ b/client/.env.development
@@ -1,1 +1,1 @@
-VITE_API_URL=http://localhost:4000/api
+VITE_API_URL=https://kontext.gosystem.io/api

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,2 +1,2 @@
-VITE_API_URL=http://localhost:4000/api
+VITE_API_URL=https://kontext.gosystem.io/api
 

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -3,11 +3,11 @@ import axios from "axios";
 // 1️⃣ first priority - env variable injected at build
 const envUrl = import.meta.env.VITE_API_URL?.trim();
 
-// 2️⃣ second - same-origin backend on :4000 (for dev preview)
-const sameOriginUrl = `${window.location.protocol}//${window.location.hostname}:4000/api`;
+// 2️⃣ fallback to production deployment
+const defaultUrl = "https://kontext.gosystem.io/api";
 
 // final baseURL
-const baseURL = envUrl || sameOriginUrl;
+const baseURL = envUrl || defaultUrl;
 
 console.log("[API] baseURL =", baseURL); // remove later
 export const api = axios.create({ baseURL, withCredentials: true });

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,13 @@
+server {
+    listen 80;
+    server_name kontext.gosystem.io;
+
+    location / {
+        proxy_pass http://127.0.0.1:4000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -48,8 +48,8 @@ const withLock = async (key, fn) => {
 
 /* ---------- express ---------- */
 const allowedOrigins = [
-  'http://localhost:5173',
-  'https://kontext.gosystem.io'
+  'https://kontext.gosystem.io',
+  'http://localhost:5173'
 ];
 
 const app = express();
@@ -250,7 +250,7 @@ if (fssync.existsSync(dist)) {
 }
 
 /* ---------- запускаем ---------- */
-const server = app.listen(4000, () =>
-  console.log('API & UI ⇒ http://localhost:4000')
+const server = app.listen(4000, '0.0.0.0', () =>
+  console.log('API & UI ⇒ http://0.0.0.0:4000')
 );
 server.setTimeout(240_000); // 4 минуты на любой запрос


### PR DESCRIPTION
## Summary
- Listen on all interfaces and default to public domain for CORS
- Point frontend API requests at https://kontext.gosystem.io
- Add example nginx reverse proxy

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6894af0ea740832ca65ddee15c8a4b1b