### PR TITLE
Add safety checks for list rendering

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -42,13 +42,18 @@ export default function App() {
   useEffect(() => {
     api.get('/loras').then((r) => setLoraList(r.data));
     (async () => {
-      const { data: boards } = await api.get('/boards');
-      setBoards(boards);
-      if (boards.length) setBid(boards[boards.length - 1].id);
+      const { data: boardsData } = await api.get('/boards');
+      if (!Array.isArray(boardsData)) {
+        console.error('Boards data should be an array', boardsData);
+        setBoards([]);
+        return;
+      }
+      setBoards(boardsData);
+      if (boardsData.length) setBid(boardsData[boardsData.length - 1].id);
       const cacheObj = {};
       const thumbsObj = {};
       await Promise.all(
-        boards.map(async (b) => {
+        boardsData.map(async (b) => {
           const { data: imgs } = await api.get(`/boards/${b.id}`);
           cacheObj[b.id] = imgs;
           cacheImages(imgs);
@@ -176,19 +181,20 @@ export default function App() {
 
       <div className="relative flex-1 overflow-y-auto">
         <div className="mx-auto grid max-w-4xl grid-cols-1 gap-6 p-6 md:grid-cols-2">
-          {gallery.map((g) =>
-            g.loading ? (
-              <LoaderCard key={g.id} />
-            ) : (
-              <ImageCard
-                key={g.id}
-                img={g}
-                boardId={bid}
-                onRemove={removeImage}
-                onShow={setShow}
-              />
-            )
-          )}
+          {Array.isArray(gallery) &&
+            gallery.map((g) =>
+              g.loading ? (
+                <LoaderCard key={g.id} />
+              ) : (
+                <ImageCard
+                  key={g.id}
+                  img={g}
+                  boardId={bid}
+                  onRemove={removeImage}
+                  onShow={setShow}
+                />
+              )
+            )}
           <div ref={bottom}></div>
         </div>
 

--- a/client/src/components/LoraModal.jsx
+++ b/client/src/components/LoraModal.jsx
@@ -17,6 +17,7 @@ export default function LoraModal({
   const [editId, setEditId] = useState(null);
   const [f, setF] = useState(blank);
   const [files, setFiles] = useState({});
+  const safeList = Array.isArray(list) ? list : [];
 
   useEffect(() => {
     if (!open) reset();
@@ -88,55 +89,61 @@ export default function LoraModal({
                 <Plus size={48} className="text-white/60" />
               </div>
 
-              {list.map((l) => (
-                <div
-                  key={l.id}
-                  onClick={() => {
-                    onPick(l);
-                    onClose();
-                  }}
-                  className="group relative flex h-[400px] w-[320px] cursor-pointer flex-col overflow-hidden rounded-2xl border border-white/10 transition-all hover:border-violet-500"
-                >
-                  <div className="flex flex-1 flex-col items-center justify-center">
-                    {l.before && l.after ? (
-                      <Compare before={l.before} after={l.after} />
-                    ) : (
-                      <img
-                        src={l.before || l.after || '/placeholder.png'}
-                        alt=""
-                        className="h-full w-full rounded-t-2xl object-cover"
-                      />
-                    )}
-                  </div>
-                  <div className="rounded-b-2xl bg-black/30 p-4 pb-2">
-                    <p className="line-clamp-1 text-lg font-semibold">{l.name}</p>
-                    {l.desc && (
-                      <p className="line-clamp-3 text-[15px] leading-tight text-white/70">
-                        {l.desc}
-                      </p>
-                    )}
-                  </div>
+              {!Array.isArray(list) ? (
+                <p className="w-full text-center text-sm text-red-400">
+                  Invalid LoRA list
+                </p>
+              ) : (
+                safeList.map((l, i) => (
+                  <div
+                    key={l.id ?? i}
+                    onClick={() => {
+                      onPick(l);
+                      onClose();
+                    }}
+                    className="group relative flex h-[400px] w-[320px] cursor-pointer flex-col overflow-hidden rounded-2xl border border-white/10 transition-all hover:border-violet-500"
+                  >
+                    <div className="flex flex-1 flex-col items-center justify-center">
+                      {l.before && l.after ? (
+                        <Compare before={l.before} after={l.after} />
+                      ) : (
+                        <img
+                          src={l.before || l.after || '/placeholder.png'}
+                          alt=""
+                          className="h-full w-full rounded-t-2xl object-cover"
+                        />
+                      )}
+                    </div>
+                    <div className="rounded-b-2xl bg-black/30 p-4 pb-2">
+                      <p className="line-clamp-1 text-lg font-semibold">{l.name}</p>
+                      {l.desc && (
+                        <p className="line-clamp-3 text-[15px] leading-tight text-white/70">
+                          {l.desc}
+                        </p>
+                      )}
+                    </div>
 
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      beginEdit(l);
-                    }}
-                    className="absolute left-2 top-2 hidden rounded p-1 hover:bg-white/10 group-hover:block"
-                  >
-                    <Pencil size={18} />
-                  </button>
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleDelete(l.id);
-                    }}
-                    className="absolute right-2 top-2 hidden rounded p-1 hover:bg-white/10 group-hover:block"
-                  >
-                    <Trash2 size={18} />
-                  </button>
-                </div>
-              ))}
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        beginEdit(l);
+                      }}
+                      className="absolute left-2 top-2 hidden rounded p-1 hover:bg-white/10 group-hover:block"
+                    >
+                      <Pencil size={18} />
+                    </button>
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleDelete(l.id);
+                      }}
+                      className="absolute right-2 top-2 hidden rounded p-1 hover:bg-white/10 group-hover:block"
+                    >
+                      <Trash2 size={18} />
+                    </button>
+                  </div>
+                ))
+              )}
             </div>
           ) : (
             <div className="space-y-5">

--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -37,27 +37,33 @@ export default function Sidebar({ boards, current, onNew, onPick, onDelete, thum
       </button>
 
       <div ref={listRef} className="flex-1 space-y-3 overflow-y-auto px-1">
-        {[...boards].reverse().map((b) => (
-          <div
-            key={b.id}
-            className={`group relative mx-auto h-20 w-20 overflow-hidden rounded border ${
-              current === b.id ? 'border-primary' : 'border-transparent'
-            }`}
-          >
-            <img
-              src={thumbs[b.id]}
-              onClick={() => onPick(b.id)}
-              onError={(e) => (e.currentTarget.style.display = 'none')}
-              className="h-full w-full cursor-pointer object-cover"
-            />
-            <button
-              onClick={() => onDelete(b.id)}
-              className="absolute -right-1 -top-1 hidden h-5 w-5 items-center justify-center rounded-full bg-black/70 text-white hover:bg-black/90 group-hover:flex"
+        {Array.isArray(boards) ? (
+          [...boards].reverse().map((b, i) => (
+            <div
+              key={b.id ?? i}
+              className={`group relative mx-auto h-20 w-20 overflow-hidden rounded border ${
+                current === b.id ? 'border-primary' : 'border-transparent'
+              }`}
             >
-              <X className="h-3 w-3" />
-            </button>
-          </div>
-        ))}
+              <img
+                src={thumbs[b.id]}
+                onClick={() => onPick(b.id)}
+                onError={(e) => (e.currentTarget.style.display = 'none')}
+                className="h-full w-full cursor-pointer object-cover"
+              />
+              <button
+                onClick={() => onDelete(b.id)}
+                className="absolute -right-1 -top-1 hidden h-5 w-5 items-center justify-center rounded-full bg-black/70 text-white hover:bg-black/90 group-hover:flex"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          ))
+        ) : (
+          <p className="text-center text-xs text-muted-foreground">
+            No boards available
+          </p>
+        )}
       </div>
 
       <button


### PR DESCRIPTION
## Summary
- Guard against non-array data when mapping boards and gallery items
- Validate LoraModal list prop and render error message on invalid data
- Ensure unique keys and fallbacks when rendering board thumbnails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --prefix client test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894b7f91820832ca0a7c9d42eb866f3