### PR TITLE
Fix CORS, data fetching, and API base URL

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -3,12 +3,12 @@ import axios from "axios";
 // 1️⃣ first priority - env variable injected at build
 const envUrl = import.meta.env.VITE_API_URL?.trim();
 
-// 2️⃣ fallback to production deployment
-const defaultUrl = "https://kontext.gosystem.io/api";
+// 2️⃣ fallbacks for dev and prod environments
+const prodUrl = 'https://kontext.gosystem.io/api';
+const devUrl = 'http://localhost:4000/api';
 
 // final baseURL
-const baseURL = envUrl || defaultUrl;
+const baseURL = envUrl || (import.meta.env.DEV ? devUrl : prodUrl);
 
-console.log("[API] baseURL =", baseURL); // remove later
 export const api = axios.create({ baseURL, withCredentials: true });
 

--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -10,7 +10,12 @@ export default function Sidebar({ boards, current, onNew, onPick, onDelete, thum
 
   const [up, setUp] = useState(false);
   const [down, setDown] = useState(false);
+
+  const list = Array.isArray(boards) ? boards : [];
   useEffect(() => {
+    if (!Array.isArray(boards)) {
+      console.error('Sidebar expected "boards" to be an array', boards);
+    }
     const el = listRef.current;
     if (!el) return;
     const calc = () => {
@@ -37,8 +42,8 @@ export default function Sidebar({ boards, current, onNew, onPick, onDelete, thum
       </button>
 
       <div ref={listRef} className="flex-1 space-y-3 overflow-y-auto px-1">
-        {Array.isArray(boards) ? (
-          [...boards].reverse().map((b, i) => (
+        {list.length ? (
+          [...list].reverse().map((b, i) => (
             <div
               key={b.id ?? i}
               className={`group relative mx-auto h-20 w-20 overflow-hidden rounded border ${

--- a/server/index.js
+++ b/server/index.js
@@ -49,26 +49,24 @@ const withLock = async (key, fn) => {
 /* ---------- express ---------- */
 const allowedOrigins = [
   'https://kontext.gosystem.io',
-  'http://localhost:5173'
+  'http://localhost:5173',
 ];
 
+const corsOptions = {
+  origin: (origin, cb) => {
+    if (!origin || allowedOrigins.includes(origin)) {
+      return cb(null, true);
+    }
+    return cb(new Error('Not allowed by CORS'));
+  },
+  credentials: true,
+  methods: ['GET', 'POST', 'PUT', 'DELETE'],
+  allowedHeaders: ['Content-Type'],
+};
+
 const app = express();
-app.use(
-  cors({
-    origin: allowedOrigins,
-    credentials: true
-  })
-);
-app.use((req, res, next) => {
-  const origin = allowedOrigins.includes(req.headers.origin)
-    ? req.headers.origin
-    : allowedOrigins[0];
-  res.setHeader('Access-Control-Allow-Origin', origin);
-  res.setHeader('Access-Control-Allow-Credentials', 'true');
-  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-  next();
-});
+app.use(cors(corsOptions));
+app.options('*', cors(corsOptions));
 app.use(express.json({ limit: '5mb' }));
 const upload = multer({ storage: multer.memoryStorage() });
 


### PR DESCRIPTION
## Summary
- restrict server CORS to kontext.gosystem.io and localhost:5173
- switch API base URL between production and local development
- guard boards prop usage with array checks and logging

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --prefix client test` *(fails: Missing script "test")*
- `npm --prefix server test` *(fails: Missing script "test")*
- `npm --prefix client run build`

------
https://chatgpt.com/codex/tasks/task_e_6894bd0df3f8832c97587bd36e3d1c05